### PR TITLE
add thread_id param

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Then configure your job to use this resource
 * `Title` (`activity` notification only) Title for the thread
 * `status_value` (`activity` notification only) Status text for the thread
 * `status_color` (`activity` notification only) Status colour for the thread
+* `thread_id` Optional. Notifications are threaded by job's name by default or if set to `job_name`. Thread by exact build number if set to `build_number`. Otherwise, thread ID is explicitly set to the configured value of this param.
 
 ## `out` Configuration
 All configuration of the resource's `source` can be overridden in the notification task's `params`

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -78,8 +78,20 @@ func buildRequestData(config *Input) map[string]interface{} {
 	job := os.Getenv(BuildJobName)
 	build := os.Getenv(BuildName)
 
-	externalThreadId := fmt.Sprintf("%s_%s_%s", team, pipeline, job)
-	threadTitle := fmt.Sprintf("%s | %s | %s [%s]", pipeline, job, build, params.StatusValue)
+	threadId := source.ThreadId
+	if params.ThreadId != "" {
+		threadId = params.ThreadId
+	}
+	externalThreadId := threadId
+	switch threadId {
+	case "", "job_name":
+		externalThreadId = fmt.Sprintf("%s_%s_%s", team, pipeline, job)
+	case "build_number":
+		externalThreadId = fmt.Sprintf("%s_%s_%s_%s", team, pipeline, job, build)
+	}
+
+	threadTitle := fmt.Sprintf("%s | %s | %s", pipeline, job, build)
+	eventTitle := fmt.Sprintf("%s | %s | %s [%s]", pipeline, job, build, params.StatusValue)
 
 	jsonData := map[string]interface{}{
 		"flow_token": flowToken,
@@ -89,7 +101,7 @@ func buildRequestData(config *Input) map[string]interface{} {
 			"name":   authorName,
 			"avatar": authorAvatar,
 		},
-		"title":              threadTitle,
+		"title":              eventTitle,
 		"external_thread_id": externalThreadId,
 		"thread": map[string]interface{}{
 			"title": threadTitle,
@@ -157,6 +169,7 @@ type Resource struct {
 	MessageBody  string `json:"message_body"`
 	StatusColour string `json:"status_colour"`
 	StatusValue  string `json:"status_value"`
+	ThreadId     string `json:"thread_id"`
 }
 
 type Input struct {

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -13,12 +13,12 @@ import (
 func metadataMap() []map[string]string {
 	metadataMap := make([]map[string]string, 6)
 
-	metadataMap[0] = buildField(BuildId, os.Getenv(BuildId))
-	metadataMap[1] = buildField(BuildName, os.Getenv(BuildName))
-	metadataMap[2] = buildField(BuildJobName, os.Getenv(BuildJobName))
-	metadataMap[3] = buildField(BuildPipelineName, os.Getenv(BuildPipelineName))
-	metadataMap[4] = buildField(BuildTeamName, os.Getenv(BuildTeamName))
-	metadataMap[5] = buildField(AtcExternalUrl, os.Getenv(AtcExternalUrl))
+	metadataMap[0] = buildField("Team", os.Getenv(BuildTeamName))
+	metadataMap[1] = buildField("Pipeline", os.Getenv(BuildPipelineName))
+	metadataMap[2] = buildField("Job", os.Getenv(BuildJobName))
+	metadataMap[3] = buildField("Build Number", os.Getenv(BuildName))
+	metadataMap[4] = buildField("Build ID", os.Getenv(BuildId))
+	metadataMap[5] = buildField("Concourse URL", os.Getenv(AtcExternalUrl))
 
 	return metadataMap
 }


### PR DESCRIPTION
added param thread_id to give user option for threading level. defaults to job_name if not configured. allowed values are 'job_name' and 'build_number'. value other than these is considered explicit thread id.